### PR TITLE
Don't reinstall addons if we've already installed the latest version.

### DIFF
--- a/.GITIGNORE
+++ b/.GITIGNORE
@@ -1,1 +1,2 @@
 in.txt
+installed.txt

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -85,7 +85,7 @@ class AddonUpdater:
             contentString = str(page.content)
             indexOfVer = contentString.find('newest-file') + 26  # Will be the index of the first char of the version string
             endTag = contentString.find('</li>', indexOfVer)     # Will be the index of the ending tag after the version string
-            return contentString[indexOfVer:endTag]
+            return contentString[indexOfVer:endTag].strip()
         except Exception:
             print('Failed to find version number for: ' + addonpage)
             return ''

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,4 @@
 [WOW ADDON UPDATER]
 WoW Addon Location = C:\Program Files (x86)\World of Warcraft\Interface\AddOns
 Addon List File = in.txt
+Installed Versions File = installed.txt


### PR DESCRIPTION
Added version tracking in an 'installed versions' file. Just add
an 'Installed Versions File' entry to config.ini and the file will
be created and populated the next time WoWAddonUpdater runs.

Then on subsequent update runs we can just read the version number
from the Curse page and if that's the version we've installed there's
no need to thrash Curse's download server.