### PR TITLE
Added support for curse projects and None check

### DIFF
--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -10,6 +10,10 @@ def findZiploc(addonpage):
     elif addonpage.startswith('https://www.curseforge.com/wow/addons/'):
         return curse(addonpage)
 
+    # Curse Project
+    elif addonpage.startswith('https://wow.curseforge.com/projects/'):
+        return curseProject(addonpage)
+		
     # Tukui
     elif addonpage.startswith('http://git.tukui.org/'):
         return tukui(addonpage)
@@ -30,6 +34,10 @@ def getCurrentVersion(addonpage):
     elif addonpage.startswith('https://www.curseforge.com/wow/addons/'):
         return getCurseVersion(addonpage)
 
+    # Curse Project
+    elif addonpage.startswith('https://wow.curseforge.com/projects/'):
+        return getCurseProjectVersion(addonpage)
+		
     # Tukui
     elif addonpage.startswith('http://git.tukui.org/'):
         return getTukuiVersion(addonpage)
@@ -63,6 +71,27 @@ def getCurseVersion(addonpage):
         contentString = str(page.content)
         indexOfVer = contentString.find('file__name full') + 17  # first char of the version string
         endTag = contentString.find('</span>', indexOfVer)  # ending tag after the version string
+        return contentString[indexOfVer:endTag].strip()
+    except Exception:
+        print('Failed to find version number for: ' + addonpage)
+        return ''
+
+# Curse Project
+
+def curseProject(addonpage):
+    try:
+        return addonpage + '/files/latest'
+    except Exception:
+        print('Failed to find downloadable zip file for addon. Skipping...\n')
+        return ''
+
+
+def getCurseProjectVersion(addonpage):
+    try:
+        page = requests.get(addonpage + '/files')
+        contentString = str(page.content)
+        indexOfVer = contentString.find('data-name') + 11  # first char of the version string
+        endTag = contentString.find('">', indexOfVer)  # ending tag after the version string
         return contentString[indexOfVer:endTag].strip()
     except Exception:
         print('Failed to find version number for: ' + addonpage)

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -48,6 +48,8 @@ class AddonUpdater:
             for line in fin:
                 line = line.rstrip('\n')
                 currentVersion = SiteHandler.getCurrentVersion(line)
+                if currentVersion is None:
+                    currentVersion = 'Not Available'
                 installedVersion = self.getInstalledVersion(line)
                 if not currentVersion == installedVersion:
                     print('Installing/updating addon: ' + line + ' to version: ' + currentVersion + '\n')
@@ -74,6 +76,7 @@ class AddonUpdater:
     def getInstalledVersion(self, addonpage):
         addonName = addonpage.replace('https://mods.curse.com/addons/wow/', '')
         addonName = addonName.replace('https://www.curseforge.com/wow/addons/', '')
+        addonName = addonName.replace('https://wow.curseforge.com/projects/', '')
         addonName = addonName.replace('http://www.wowinterface.com/downloads/', '')
         installedVers = configparser.ConfigParser()
         installedVers.read(self.INSTALLED_VERS_FILE)
@@ -85,6 +88,7 @@ class AddonUpdater:
     def setInstalledVersion(self, addonpage, currentVersion):
         addonName = addonpage.replace('https://mods.curse.com/addons/wow/', '')
         addonName = addonName.replace('https://www.curseforge.com/wow/addons/', '')
+        addonName = addonName.replace('https://wow.curseforge.com/projects/', '')
         addonName = addonName.replace('http://www.wowinterface.com/downloads/', '')
         installedVers = configparser.ConfigParser()
         installedVers.read(self.INSTALLED_VERS_FILE)


### PR DESCRIPTION
I was having trouble with the raider.io addon. Which by default was throwing an error that a string was null, so I added a null check and added support for curseforge's project pages.