### PR TITLE
Filter out empty lines in addon list file

### DIFF
--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -47,6 +47,8 @@ class AddonUpdater:
         with open(self.ADDON_LIST_FILE, "r") as fin:
             for line in fin:
                 line = line.rstrip('\n')
+                if not len(line):
+                    continue
                 currentVersion = SiteHandler.getCurrentVersion(line)
                 installedVersion = self.getInstalledVersion(line)
                 if not currentVersion == installedVersion:


### PR DESCRIPTION
I had an extra new line in my config file that was causing a crash. I updated the tool to not crash in this case.