### PR TITLE
Use alpha versions of datastore* mods.

### DIFF
--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -86,6 +86,7 @@ def curse(addonpage):
         return curseDatastore(addonpage)
     try:
         page = requests.get(addonpage + '/download')
+        page.raise_for_status()
         contentString = str(page.content)
         indexOfZiploc = contentString.find('download__link') + 22  # Will be the index of the first char of the url
         endQuote = contentString.find('"', indexOfZiploc)  # Will be the index of the ending quote after the url
@@ -98,6 +99,7 @@ def curseDatastore(addonpage):
     try:
         # First, look for the URL of the project file page
         page = requests.get(addonpage)
+        page.raise_for_status()
         contentString = str(page.content)
         endOfProjectPageURL = contentString.find('">Visit Project Page')
         indexOfProjectPageURL = contentString.rfind('<a href="', 0, endOfProjectPageURL) + 9
@@ -105,6 +107,7 @@ def curseDatastore(addonpage):
 
         # Then get the project page and get the URL of the first (most recent) file
         page = requests.get(projectPage)
+        page.raise_for_status()
         projectPage = page.url  # We might get redirected, need to know where we ended up.
         contentString = str(page.content)
         startOfTable = contentString.find('project-file-name-container')
@@ -125,6 +128,7 @@ def convertOldCurseURL(addonpage):
         # name and URL is, just try to load the old URL and see where Curse redirects us to. We can guess at
         # the new URL, but they should know their own renaming scheme better than we do.
         page = requests.get(addonpage)
+        page.raise_for_status()
         return page.url
     except Exception:
         print('Failed to find the current page for old URL "' + addonpage + '". Skipping...\n')
@@ -139,6 +143,7 @@ def getCurseVersion(addonpage):
         return getCurseDatastoreVersion(addonpage)
     try:
         page = requests.get(addonpage + '/files')
+        page.raise_for_status()
         contentString = str(page.content)
         indexOfVer = contentString.find('file__name full') + 17  # first char of the version string
         endTag = contentString.find('</span>', indexOfVer)  # ending tag after the version string
@@ -151,6 +156,7 @@ def getCurseDatastoreVersion(addonpage):
     try:
         # First, look for the URL of the project file page
         page = requests.get(addonpage)
+        page.raise_for_status()
         contentString = str(page.content)
         endOfProjectPageURL = contentString.find('">Visit Project Page')
         indexOfProjectPageURL = contentString.rfind('<a href="', 0, endOfProjectPageURL) + 9
@@ -166,6 +172,12 @@ def getCurseDatastoreVersion(addonpage):
 
 def curseProject(addonpage):
     try:
+        # Apparently the Curse project pages are sometimes sending people to WowAce now.
+        # Check if the URL forwards to WowAce and use that URL instead.
+        page = requests.get(addonpage)
+        page.raise_for_status()
+        if page.url.startswith('https://www.wowace.com/projects/'):
+            return wowAceProject(page.url)
         return addonpage + '/files/latest'
     except Exception:
         print('Failed to find downloadable zip file for addon. Skipping...\n')
@@ -175,6 +187,11 @@ def curseProject(addonpage):
 def getCurseProjectVersion(addonpage):
     try:
         page = requests.get(addonpage + '/files')
+        if page.status_code == 404:
+            # Maybe the project page got moved to WowAce?
+            page = requests.get(addonpage)
+            page = requests.get(page.url + '/files')
+            page.raise_for_status()
         contentString = str(page.content)
         startOfTable = contentString.find('project-file-list-item')
         indexOfVer = contentString.find('data-name="', startOfTable) + 11  # first char of the version string
@@ -198,6 +215,7 @@ def wowAceProject(addonpage):
 def getWowAceProjectVersion(addonpage):
     try:
         page = requests.get(addonpage + '/files')
+        page.raise_for_status()
         contentString = str(page.content)
         startOfTable = contentString.find('project-file-list-item')
         indexOfVer = contentString.find('data-name="', startOfTable) + 11  # first char of the version string
@@ -226,6 +244,7 @@ def wowinterface(addonpage):
     downloadpage = addonpage.replace('info', 'download')
     try:
         page = requests.get(downloadpage + '/download')
+        page.raise_for_status()
         contentString = str(page.content)
         indexOfZiploc = contentString.find('Problems with the download? <a href="') + 37  # first char of the url
         endQuote = contentString.find('"', indexOfZiploc)  # ending quote after the url
@@ -238,6 +257,7 @@ def wowinterface(addonpage):
 def getWowinterfaceVersion(addonpage):
     try:
         page = requests.get(addonpage)
+        page.raise_for_status()
         contentString = str(page.content)
         indexOfVer = contentString.find('id="version"') + 22  # first char of the version string
         endTag = contentString.find('</div>', indexOfVer)  # ending tag after the version string

--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -13,7 +13,7 @@ def findZiploc(addonpage):
     # Curse Project
     elif addonpage.startswith('https://wow.curseforge.com/projects/'):
         return curseProject(addonpage)
-		
+
     # Tukui
     elif addonpage.startswith('http://git.tukui.org/'):
         return tukui(addonpage)
@@ -37,7 +37,7 @@ def getCurrentVersion(addonpage):
     # Curse Project
     elif addonpage.startswith('https://wow.curseforge.com/projects/'):
         return getCurseProjectVersion(addonpage)
-		
+
     # Tukui
     elif addonpage.startswith('http://git.tukui.org/'):
         return getTukuiVersion(addonpage)

--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -18,6 +18,14 @@ def findZiploc(addonpage):
         else:
             return curseProject(addonpage)
 
+    # WowAce Project
+    elif addonpage.startswith('https://www.wowace.com/projects/'):
+        if addonpage.endswith('/files'):
+            # Remove /files from the end of the URL, since it gets added later
+            return wowAceProject(addonpage[:-6])
+        else:
+            return wowAceProject(addonpage)
+
     # Tukui
     elif addonpage.startswith('http://git.tukui.org/'):
         return tukui(addonpage)
@@ -42,6 +50,10 @@ def getCurrentVersion(addonpage):
     elif addonpage.startswith('https://wow.curseforge.com/projects/'):
         return getCurseProjectVersion(addonpage)
 
+    # WowAce Project
+    elif addonpage.startswith('https://www.wowace.com/projects/'):
+        return getWowAceProjectVersion(addonpage)
+
     # Tukui
     elif addonpage.startswith('http://git.tukui.org/'):
         return getTukuiVersion(addonpage)
@@ -61,6 +73,7 @@ def getAddonName(addonpage):
     addonName = addonName.replace('https://www.curseforge.com/wow/addons/', '')
     addonName = addonName.replace('https://wow.curseforge.com/projects/', '')
     addonName = addonName.replace('http://www.wowinterface.com/downloads/', '')
+    addonName = addonName.replace('https://www.wowace.com/projects/', '')
     if addonName.endswith('/files'):
         addonName = addonName[:-6]
     return addonName
@@ -160,6 +173,29 @@ def curseProject(addonpage):
 
 
 def getCurseProjectVersion(addonpage):
+    try:
+        page = requests.get(addonpage + '/files')
+        contentString = str(page.content)
+        startOfTable = contentString.find('project-file-list-item')
+        indexOfVer = contentString.find('data-name="', startOfTable) + 11  # first char of the version string
+        endTag = contentString.find('">', indexOfVer)  # ending tag after the version string
+        return contentString[indexOfVer:endTag].strip()
+    except Exception:
+        print('Failed to find version number for: ' + addonpage)
+        return ''
+
+
+# WowAce Project
+
+def wowAceProject(addonpage):
+    try:
+        return addonpage + '/files/latest'
+    except Exception:
+        print('Failed to find downloadable zip file for addon. Skipping...\n')
+        return ''
+
+
+def getWowAceProjectVersion(addonpage):
     try:
         page = requests.get(addonpage + '/files')
         contentString = str(page.content)

--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -55,6 +55,17 @@ def getCurrentVersion(addonpage):
         print('Invalid addon page.')
 
 
+def getAddonName(addonpage):
+    # Might actually read names from web pages later
+    addonName = addonpage.replace('https://mods.curse.com/addons/wow/', '')
+    addonName = addonName.replace('https://www.curseforge.com/wow/addons/', '')
+    addonName = addonName.replace('https://wow.curseforge.com/projects/', '')
+    addonName = addonName.replace('http://www.wowinterface.com/downloads/', '')
+    if addonName.endswith('/files'):
+        addonName = addonName[:-6]
+    return addonName
+
+
 # Curse
 
 def curse(addonpage):

--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -12,7 +12,11 @@ def findZiploc(addonpage):
 
     # Curse Project
     elif addonpage.startswith('https://wow.curseforge.com/projects/'):
-        return curseProject(addonpage)
+        if addonpage.endswith('/files'):
+            # Remove /files from the end of the URL, since it gets added later
+            return curseProject(addonpage[:-6])
+        else:
+            return curseProject(addonpage)
 
     # Tukui
     elif addonpage.startswith('http://git.tukui.org/'):

--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -79,7 +79,8 @@ def curseDatastore(addonpage):
         page = requests.get(projectPage)
         projectPage = page.url  # We might get redirected, need to know where we ended up.
         contentString = str(page.content)
-        indexOfZiploc = contentString.find('<a class="button tip fa-icon-download icon-only" href="/') + 55
+        startOfTable = contentString.find('project-file-name-container')
+        indexOfZiploc = contentString.find('<a class="button tip fa-icon-download icon-only" href="/', startOfTable) + 55
         endOfZiploc = contentString.find('"', indexOfZiploc)
 
         # Add on the first part of the project page URL to get a complete URL
@@ -125,14 +126,10 @@ def getCurseDatastoreVersion(addonpage):
         contentString = str(page.content)
         endOfProjectPageURL = contentString.find('">Visit Project Page')
         indexOfProjectPageURL = contentString.rfind('<a href="', 0, endOfProjectPageURL) + 9
-        projectPage = contentString[indexOfProjectPageURL:endOfProjectPageURL] + '/files'
+        projectPage = contentString[indexOfProjectPageURL:endOfProjectPageURL]
 
-        # Then get the project page and get the version of the first (most recent) file
-        page = requests.get(projectPage)
-        contentString = str(page.content)
-        indexOfVer = contentString.find('data-name="') + 11
-        endOfVer = contentString.find('"', indexOfVer)
-        return contentString[indexOfVer:endOfVer].strip()
+        # Now just call getCurseProjectVersion with the URL we found
+        return getCurseProjectVersion(projectPage)
     except Exception:
         print('Failed to find alpha version number for: ' + addonpage)
 
@@ -151,7 +148,8 @@ def getCurseProjectVersion(addonpage):
     try:
         page = requests.get(addonpage + '/files')
         contentString = str(page.content)
-        indexOfVer = contentString.find('data-name') + 11  # first char of the version string
+        startOfTable = contentString.find('project-file-list-item')
+        indexOfVer = contentString.find('data-name="', startOfTable) + 11  # first char of the version string
         endTag = contentString.find('">', indexOfVer)  # ending tag after the version string
         return contentString[indexOfVer:endTag].strip()
     except Exception:

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -60,9 +60,10 @@ class AddonUpdater:
                 if not currentVersion == installedVersion:
                     print('Installing/updating addon: ' + line + ' to version: ' + currentVersion + '\n')
                     ziploc = SiteHandler.findZiploc(line)
-                    self.getAddon(ziploc)
+                    install_success = False
+                    install_success = self.getAddon(ziploc)
                     current_node.append(self.getInstalledVersion(line))
-                    if currentVersion is not '':
+                    if install_success is True and currentVersion is not '':
                         self.setInstalledVersion(line, currentVersion)
                 else:
                     print(line + ' version ' + currentVersion + ' is up to date.\n')
@@ -77,14 +78,15 @@ class AddonUpdater:
 
     def getAddon(self, ziploc):
         if ziploc == '':
-            return
+            return False
         try:
             r = requests.get(ziploc, stream=True)
             z = zipfile.ZipFile(BytesIO(r.content))
             z.extractall(self.WOW_ADDON_LOCATION)
+            return True
         except Exception:
             print('Failed to download or extract zip file for addon. Skipping...\n')
-            return
+            return False
 
     def getInstalledVersion(self, addonpage):
         addonName = addonpage.replace('https://mods.curse.com/addons/wow/', '')

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -51,14 +51,15 @@ class AddonUpdater:
                 line = line.rstrip('\n')
                 if not line or line.startswith('#'):
                     continue
+                addonName = SiteHandler.getAddonName(line)
                 currentVersion = SiteHandler.getCurrentVersion(line)
                 if currentVersion is None:
                     currentVersion = 'Not Available'
-                current_node.append(line.split("/")[-1])
+                current_node.append(addonName)
                 current_node.append(currentVersion)
                 installedVersion = self.getInstalledVersion(line)
                 if not currentVersion == installedVersion:
-                    print('Installing/updating addon: ' + line + ' to version: ' + currentVersion + '\n')
+                    print('Installing/updating addon: ' + addonName + ' to version: ' + currentVersion + '\n')
                     ziploc = SiteHandler.findZiploc(line)
                     install_success = False
                     install_success = self.getAddon(ziploc)
@@ -66,7 +67,7 @@ class AddonUpdater:
                     if install_success is True and currentVersion is not '':
                         self.setInstalledVersion(line, currentVersion)
                 else:
-                    print(line + ' version ' + currentVersion + ' is up to date.\n')
+                    print(addonName + ' version ' + currentVersion + ' is up to date.\n')
                     current_node.append("Up to date")
                 uberlist.append(current_node)
         if self.AUTO_CLOSE == 'False':
@@ -89,10 +90,7 @@ class AddonUpdater:
             return False
 
     def getInstalledVersion(self, addonpage):
-        addonName = addonpage.replace('https://mods.curse.com/addons/wow/', '')
-        addonName = addonName.replace('https://www.curseforge.com/wow/addons/', '')
-        addonName = addonName.replace('https://wow.curseforge.com/projects/', '')
-        addonName = addonName.replace('http://www.wowinterface.com/downloads/', '')
+        addonName = SiteHandler.getAddonName(addonpage)
         installedVers = configparser.ConfigParser()
         installedVers.read(self.INSTALLED_VERS_FILE)
         try:
@@ -101,10 +99,7 @@ class AddonUpdater:
             return 'version not found'
 
     def setInstalledVersion(self, addonpage, currentVersion):
-        addonName = addonpage.replace('https://mods.curse.com/addons/wow/', '')
-        addonName = addonName.replace('https://www.curseforge.com/wow/addons/', '')
-        addonName = addonName.replace('https://wow.curseforge.com/projects/', '')
-        addonName = addonName.replace('http://www.wowinterface.com/downloads/', '')
+        addonName = SiteHandler.getAddonName(addonpage)
         installedVers = configparser.ConfigParser()
         installedVers.read(self.INSTALLED_VERS_FILE)
         installedVers.set('Installed Versions', addonName, currentVersion)

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -55,7 +55,7 @@ class AddonUpdater:
                 if currentVersion is None:
                     currentVersion = 'Not Available'
                 current_node.append(line.split("/")[-1])
-                current_node.append(SiteHandler.getCurrentVersion(line))
+                current_node.append(currentVersion)
                 installedVersion = self.getInstalledVersion(line)
                 if not currentVersion == installedVersion:
                     print('Installing/updating addon: ' + line + ' to version: ' + currentVersion + '\n')


### PR DESCRIPTION
For some reason, the dev for the DataStore addons stopped doing actual releases back
around the start of WoD and now just does alpha releases on the project page. So installing
the latest 'release' version gets you a version from 2014 that doesn't work.

This grabs the latest alpha from the project page instead.