### PR TITLE
Checked for more edge cases, such as fail to find or fail to extract

### DIFF
--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -1,5 +1,6 @@
 import packages.requests as requests
 
+MAX_VERSION_LENGTH = 300
 
 # Site splitter
 
@@ -57,8 +58,12 @@ def curse(addonpage):
     try:
         page = requests.get(addonpage + '/download')
         contentString = str(page.content)
-        indexOfZiploc = contentString.find('download__link') + 22  # Will be the index of the first char of the url
+        indexOfZiploc = contentString.find('download__link')  # Will be the index of the first char of the url
+        if -1 == indexOfZipLoc:
+            raise Exception('Unable to find link')
+        indexOfZipLoc += 22
         endQuote = contentString.find('"', indexOfZiploc)  # Will be the index of the ending quote after the url
+        print(contentString[indexOfZiploc:endQuote])
         return 'https://www.curseforge.com' + contentString[indexOfZiploc:endQuote]
     except Exception:
         print('Failed to find downloadable zip file for addon. Skipping...\n')
@@ -79,9 +84,14 @@ def getCurseVersion(addonpage):
     try:
         page = requests.get(addonpage + '/files')
         contentString = str(page.content)
-        indexOfVer = contentString.find('file__name full') + 17  # first char of the version string
+        indexOfVer = contentString.find('file__name full')  # first char of the version string
+        if -1 == indexOfVer:
+            raise Exception('Unable to find link')
+        indexOfVer += 17
         endTag = contentString.find('</span>', indexOfVer)  # ending tag after the version string
-        return contentString[indexOfVer:endTag].strip()
+        if endTag - indexOfVer > MAX_VERSION_LENGTH:
+            endTag = indexOfVer + MAX_VERSION_LENGTH
+        return contentString[indexOfVer:endTag].strip().replace('\n', 'n').replace('=', 'e')
     except Exception:
         print('Failed to find version number for: ' + addonpage)
         return ''
@@ -100,9 +110,14 @@ def getCurseProjectVersion(addonpage):
     try:
         page = requests.get(addonpage + '/files')
         contentString = str(page.content)
-        indexOfVer = contentString.find('data-name') + 11  # first char of the version string
+        indexOfVer = contentString.find('data-name')  # first char of the version string
+        if -1 == indexOfVer:
+            raise Exception('Unable to find link')
+        indexOfVer += 11
         endTag = contentString.find('">', indexOfVer)  # ending tag after the version string
-        return contentString[indexOfVer:endTag].strip()
+        if endTag - indexOfVer > MAX_VERSION_LENGTH:
+            endTag = indexOfVer + MAX_VERSION_LENGTH
+        return contentString[indexOfVer:endTag].strip().replace('\n', 'n').replace('=', 'e')
     except Exception:
         print('Failed to find version number for: ' + addonpage)
         return ''
@@ -127,7 +142,9 @@ def wowinterface(addonpage):
     try:
         page = requests.get(downloadpage + '/download')
         contentString = str(page.content)
-        indexOfZiploc = contentString.find('Problems with the download? <a href="') + 37  # first char of the url
+        indexOfZiploc = contentString.find('Problems with the download? <a href="')  # first char of the url
+        if -1 == indexOfZipLoc:
+            raise Exception('Unable to find link')
         endQuote = contentString.find('"', indexOfZiploc)  # ending quote after the url
         return contentString[indexOfZiploc:endQuote]
     except Exception:
@@ -139,9 +156,14 @@ def getWowinterfaceVersion(addonpage):
     try:
         page = requests.get(addonpage)
         contentString = str(page.content)
-        indexOfVer = contentString.find('id="version"') + 22  # first char of the version string
+        indexOfVer = contentString.find('id="version"')  # first char of the version string
+        if -1 == indexOfVer:
+            raise Exception('Unable to find link')
+        indexOfVer += 22
         endTag = contentString.find('</div>', indexOfVer)  # ending tag after the version string
-        return contentString[indexOfVer:endTag].strip()
+        if endTag - indexOfVer > MAX_VERSION_LENGTH:
+            endTag = indexOfVer + MAX_VERSION_LENGTH
+        return contentString[indexOfVer:endTag].strip().replace('\n', 'n').replace('=', 'e')
     except Exception:
         print('Failed to find version number for: ' + addonpage)
         return ''

--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -145,6 +145,7 @@ def wowinterface(addonpage):
         indexOfZiploc = contentString.find('Problems with the download? <a href="')  # first char of the url
         if -1 == indexOfZipLoc:
             raise Exception('Unable to find link')
+        indexOfZiploc += 37
         endQuote = contentString.find('"', indexOfZiploc)  # ending quote after the url
         return contentString[indexOfZiploc:endQuote]
     except Exception:

--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -63,7 +63,6 @@ def curse(addonpage):
             raise Exception('Unable to find link')
         indexOfZipLoc += 22
         endQuote = contentString.find('"', indexOfZiploc)  # Will be the index of the ending quote after the url
-        print(contentString[indexOfZiploc:endQuote])
         return 'https://www.curseforge.com' + contentString[indexOfZiploc:endQuote]
     except Exception:
         print('Failed to find downloadable zip file for addon. Skipping...\n')

--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -59,9 +59,9 @@ def curse(addonpage):
         page = requests.get(addonpage + '/download')
         contentString = str(page.content)
         indexOfZiploc = contentString.find('download__link')  # Will be the index of the first char of the url
-        if -1 == indexOfZipLoc:
+        if -1 == indexOfZiploc:
             raise Exception('Unable to find link')
-        indexOfZipLoc += 22
+        indexOfZiploc += 22
         endQuote = contentString.find('"', indexOfZiploc)  # Will be the index of the ending quote after the url
         return 'https://www.curseforge.com' + contentString[indexOfZiploc:endQuote]
     except Exception:

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -53,16 +53,17 @@ class AddonUpdater:
                     continue
                 currentVersion = SiteHandler.getCurrentVersion(line)
                 if currentVersion is None:
-                    currentVersion = 'Not Available'
+                    currentVersion = ''
                 current_node.append(line.split("/")[-1])
                 current_node.append(SiteHandler.getCurrentVersion(line))
                 installedVersion = self.getInstalledVersion(line)
                 if not currentVersion == installedVersion:
                     print('Installing/updating addon: ' + line + ' to version: ' + currentVersion + '\n')
                     ziploc = SiteHandler.findZiploc(line)
-                    self.getAddon(ziploc)
+                    if not self.getAddon(ziploc):
+                        ziploc = ''
                     current_node.append(self.getInstalledVersion(line))
-                    if currentVersion is not '':
+                    if currentVersion is not '' and ziploc is not '':
                         self.setInstalledVersion(line, currentVersion)
                 else:
                     print(line + ' version ' + currentVersion + ' is up to date.\n')
@@ -77,14 +78,15 @@ class AddonUpdater:
 
     def getAddon(self, ziploc):
         if ziploc == '':
-            return
+            return False
         try:
             r = requests.get(ziploc, stream=True)
             z = zipfile.ZipFile(BytesIO(r.content))
             z.extractall(self.WOW_ADDON_LOCATION)
+            return True
         except Exception:
             print('Failed to download or extract zip file for addon. Skipping...\n')
-            return
+            return False
 
     def getInstalledVersion(self, addonpage):
         addonName = addonpage.replace('https://mods.curse.com/addons/wow/', '')


### PR DESCRIPTION
I'm not sure what curse has changed, but I was getting -1 returns on find that was putting very large 2,500 character versions including equal signs and line returns. These strange versions where messing up my installed.txt. So I added a check for when find returns -1, put a max character limit on versions of 300 characters, and replaced line returns and equal signs in versions with less harmful characters. I also had it changing my version even when the download failed, so I added a check to make sure it made it past the extraction before changing the version.