### PR TITLE
Remove existing addon before copying new one into place

### DIFF
--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -105,7 +105,11 @@ class AddonUpdater:
                     zip.extractall(tempDirPath)
                     extractedFolderPath = join(tempDirPath, listdir(tempDirPath)[0])
                     subfolderPath = join(extractedFolderPath, subfolder)
-                    shutil.copytree(subfolderPath, join(self.WOW_ADDON_LOCATION, subfolder))
+                    destination_dir = join(self.WOW_ADDON_LOCATION, subfolder)
+                    # Delete the existing copy, as shutil.copytree will not work if
+                    # the destination directory already exists!
+                    shutil.rmtree(destination_dir, ignore_errors=True)
+                    shutil.copytree(subfolderPath, destination_dir)
             except Exception as ex:
                 print('Failed to get subfolder ' + subfolder)
 


### PR DESCRIPTION
I'm surprised there are no open issues about this.. but the Tukui support does not seem to work. After digging around I found it's because of the use of shutil.copytree() to move the newly-extracted addon into place. This function fails if the destination directory already exists. 

Removing the destination dir tree first solves the problem.