### PR TITLE
Addon Uninstaller

### DIFF
--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -1,17 +1,15 @@
 import zipfile, configparser
 from io import BytesIO
-from os.path import isfile, join
+from os.path import isfile, join, isdir
 from os import listdir
 import shutil
 import tempfile
 import SiteHandler
 import packages.requests as requests
 
-
 def confirmExit():
     input('\nPress the Enter key to exit')
     exit(0)
-
 
 class AddonUpdater:
     def __init__(self):
@@ -39,10 +37,8 @@ class AddonUpdater:
             confirmExit()
 
         if not isfile(self.INSTALLED_VERS_FILE):
-            with open(self.INSTALLED_VERS_FILE, 'w') as newInstalledVersFile:
-                newInstalledVers = configparser.ConfigParser()
-                newInstalledVers['Installed Versions'] = {}
-                newInstalledVers.write(newInstalledVersFile)
+            open(self.INSTALLED_VERS_FILE, 'w') # Create installed versions file since it doesn't exist
+
         return
 
     def update(self):
@@ -69,10 +65,10 @@ class AddonUpdater:
                     print('Installing/updating addon: ' + addonName + ' to version: ' + currentVersion + '\n')
                     ziploc = SiteHandler.findZiploc(line)
                     install_success = False
-                    install_success = self.getAddon(ziploc, subfolder)
-                    current_node.append(self.getInstalledVersion(line))
-                    if install_success is True and currentVersion is not '':
-                        self.setInstalledVersion(line, currentVersion)
+                    install_success = self.getAddon(ziploc, subfolder) # install_success[1] is list of subfolders
+                    current_node.append(self.getInstalledVersion(line)) 
+                    if install_success[0] is True and currentVersion is not '':
+                        self.setInstalledVersion(line, currentVersion, install_success[1])
                 else:
                     print(addonName + ' version ' + currentVersion + ' is up to date.\n')
                     current_node.append("Up to date")
@@ -91,11 +87,19 @@ class AddonUpdater:
             r = requests.get(ziploc, stream=True)
             z = zipfile.ZipFile(BytesIO(r.content))
             self.extract(z, ziploc, subfolder)
-            return True
+            return (True, self.getFolderNames(z))
         except Exception:
             print('Failed to download or extract zip file for addon. Skipping...\n')
-            return False
+            return (False, [])
     
+    def getFolderNames(self, zip):
+        parent_folders = []
+        for i in zip.namelist():
+            i = i.split('/')[0]
+            if i not in parent_folders:
+                parent_folders.append(i)
+        return parent_folders
+
     def extract(self, zip, url, subfolder):
         if subfolder == '':
             zip.extractall(self.WOW_ADDON_LOCATION)
@@ -105,37 +109,58 @@ class AddonUpdater:
                     zip.extractall(tempDirPath)
                     extractedFolderPath = join(tempDirPath, listdir(tempDirPath)[0])
                     subfolderPath = join(extractedFolderPath, subfolder)
-                    destination_dir = join(self.WOW_ADDON_LOCATION, subfolder)
-                    # Delete the existing copy, as shutil.copytree will not work if
-                    # the destination directory already exists!
-                    shutil.rmtree(destination_dir, ignore_errors=True)
-                    shutil.copytree(subfolderPath, destination_dir)
+                    shutil.copytree(subfolderPath, join(self.WOW_ADDON_LOCATION, subfolder))
             except Exception as ex:
                 print('Failed to get subfolder ' + subfolder)
 
     def getInstalledVersion(self, addonpage):
-        addonName = SiteHandler.getAddonName(addonpage)
         installedVers = configparser.ConfigParser()
         installedVers.read(self.INSTALLED_VERS_FILE)
         try:
-            return installedVers['Installed Versions'][addonName]
+            return installedVers[addonpage]['version']
         except Exception:
             return 'version not found'
 
-    def setInstalledVersion(self, addonpage, currentVersion):
-        addonName = SiteHandler.getAddonName(addonpage)
-        installedVers = configparser.ConfigParser()
-        installedVers.read(self.INSTALLED_VERS_FILE)
-        installedVers.set('Installed Versions', addonName, currentVersion)
-        with open(self.INSTALLED_VERS_FILE, 'w') as installedVersFile:
-            installedVers.write(installedVersFile)
+    def setInstalledVersion(self, addonpage, currentVersion, folders):
+        addonName = addonpage
+        config = configparser.ConfigParser()
+        config.read(self.INSTALLED_VERS_FILE)
+        try:
+            config.get(addonName, 'version')    # If the addon is already installed, fetch
+            config.get(addonName, 'folders')    # its version and folders
+        except:
+            config.add_section(addonName)       # Otherwise create a new section
+        config.set(addonName, 'version', currentVersion)    # Set its version
+        config.set(addonName, 'folders', str(folders)[1 : -1].replace("'","").replace(" ",""))  # List all folders
+        with open(self.INSTALLED_VERS_FILE, 'w') as installedVersFile:                          # it creates
+            config.write(installedVersFile)
 
+    def diff(self, a, b): # Returns all items in list a that are not in list b
+        return [item for item in a if item not in set(b)]
+
+    def uninstallAddon(self): # Allows user to uninstall addon by removing its URL from ADDON_LIST_FILE
+        with open(self.ADDON_LIST_FILE) as f:   # Read all URLs in ADDON_LIST_FILE into a list
+            content = f.read().splitlines()
+        config = configparser.ConfigParser()    # Read INSTALLED_VERS_FILE
+        config.read(self.INSTALLED_VERS_FILE)
+        installed = [section for section in config.sections()]  # Put all URLs in INSTALLED_VERS_FILE into a list
+        for to_del in self.diff(installed, content):            # Get diff of two lists. The resulting list
+            print("Uninstall {} ...".format(to_del))            # will be URLs not in the addon list file
+            for folder in config.get(to_del, 'folders').split(','): # Proceed to delete all addon folders by reading
+                if (isdir(join(self.WOW_ADDON_LOCATION, folder))):  # the INSTALLED_VERS_FILE
+                    print("\t{}".format(folder))
+                    shutil.rmtree(join(self.WOW_ADDON_LOCATION, folder))
+                else:
+                    print("\tCannot find {}".format(join(self.WOW_ADDON_LOCATION, folder)))
+            config.remove_section(to_del)                           # Remove the addon entry from INSTALLED_VERS_FILE
+            with open(self.INSTALLED_VERS_FILE, 'w') as installedVersFile:
+                config.write(installedVersFile)
 
 def main():
     addonupdater = AddonUpdater()
     addonupdater.update()
+    addonupdater.uninstallAddon()
     return
-
 
 if __name__ == "__main__":
     # execute only if run as a script

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -140,7 +140,7 @@ class AddonUpdater:
 
     def uninstallAddon(self): # Allows user to uninstall addon by removing its URL from ADDON_LIST_FILE
         with open(self.ADDON_LIST_FILE) as f:   # Read all URLs in ADDON_LIST_FILE into a list
-            content = f.read().splitlines()
+            content = [i.replace('#', '') for i in f.read().splitlines()]
         config = configparser.ConfigParser()    # Read INSTALLED_VERS_FILE
         config.read(self.INSTALLED_VERS_FILE)
         installed = [section for section in config.sections()]  # Put all URLs in INSTALLED_VERS_FILE into a list

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -37,7 +37,7 @@ class AddonUpdater:
             confirmExit()
 
         if not isfile(self.INSTALLED_VERS_FILE):
-            open(self.INSTALLED_VERS_FILE, 'w') # Create installed versions file since it doesn't exist
+            open(self.INSTALLED_VERS_FILE, 'w').close() # Create installed versions file if it doesn't exist
 
         return
 


### PR DESCRIPTION
- Modified _Installed Versions File_ to the following format
```
[<addon URL>]
version = <addon version>
folders = <addon subfolder 1>, <addon subfolder 2>, .... <addon subfolder n>
```
- Added new function `uninstallAddon()` that allows a user to uninstall an add-on by removing the addon's URL from the Addon List File. 
- Addons whose URLs that are commented with _#_ will not be deleted
- **Note: Users will need to delete their _Installed Versions File_ and run the script to re-generate it. Otherwise it won't be able to associate the folder with the addon.**
- Not tested on Mac