### PR TITLE
Fix site to workwith curseforges update and add classic/retail version check

### DIFF
--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -88,7 +88,8 @@ def curse(addonpage):
         page = requests.get(addonpage + '/download')
         page.raise_for_status()   # Raise an exception for HTTP errors
         contentString = str(page.content)
-        indexOfZiploc = contentString.find('download__link') + 22  # Will be the index of the first char of the url
+        searchString = addonpage[26:] + '/download/'
+        indexOfZiploc = contentString.find(searchString)  # Will be the index of the first char of the url
         endQuote = contentString.find('"', indexOfZiploc)  # Will be the index of the ending quote after the url
         return 'https://www.curseforge.com' + contentString[indexOfZiploc:endQuote]
     except Exception:
@@ -145,8 +146,8 @@ def getCurseVersion(addonpage):
         page = requests.get(addonpage + '/files')
         page.raise_for_status()   # Raise an exception for HTTP errors
         contentString = str(page.content)
-        indexOfVer = contentString.find('file__name full') + 17  # first char of the version string
-        endTag = contentString.find('</span>', indexOfVer)  # ending tag after the version string
+        indexOfVer = contentString.find('text-primary-500 text-lg') + 26 # first char of the version string
+        endTag = contentString.find('</h3>', indexOfVer)  # ending tag after the version string
         return contentString[indexOfVer:endTag].strip()
     except Exception:
         print('Failed to find version number for: ' + addonpage)

--- a/SiteHandler.py
+++ b/SiteHandler.py
@@ -1,14 +1,16 @@
 import packages.requests as requests
 import re
-
+import collections
 # Site splitter
 
-def findZiploc(addonpage):
+VersionLink = collections.namedtuple('VersionLink', 'version link')
+
+def findZiploc(addonpage, wow_min, wow_max):
     # Curse
     if addonpage.startswith('https://mods.curse.com/addons/wow/'):
-        return curse(convertOldCurseURL(addonpage))
+        return curse(convertOldCurseURL(addonpage), wow_min, wow_max)
     elif addonpage.startswith('https://www.curseforge.com/wow/addons/'):
-        return curse(addonpage)
+        return curse(addonpage, wow_min, wow_max)
 
     # Curse Project
     elif addonpage.startswith('https://wow.curseforge.com/projects/'):
@@ -39,12 +41,12 @@ def findZiploc(addonpage):
         print('Invalid addon page.')
 
 
-def getCurrentVersion(addonpage):
+def getCurrentVersion(addonpage, wow_min, wow_max):
     # Curse
     if addonpage.startswith('https://mods.curse.com/addons/wow/'):
-        return getCurseVersion(convertOldCurseURL(addonpage))
+        return getCurseVersion(convertOldCurseURL(addonpage), wow_min, wow_max)
     elif addonpage.startswith('https://www.curseforge.com/wow/addons/'):
-        return getCurseVersion(addonpage)
+        return getCurseVersion(addonpage, wow_min, wow_max)
 
     # Curse Project
     elif addonpage.startswith('https://wow.curseforge.com/projects/'):
@@ -78,22 +80,75 @@ def getAddonName(addonpage):
         addonName = addonName[:-6]
     return addonName
 
-
+def gameVersionLessThanOrEqual(version_one, version_two):
+    version_one = version_one.strip()
+    version_two = version_two.strip()
+    prev_dot_location_one = 0
+    prev_dot_location_two = 0
+    while(prev_dot_location_one >= 0 and prev_dot_location_two >= 0):
+        next_dot_location_one = version_one.find('.', prev_dot_location_one)
+        next_dot_location_two = version_two.find('.', prev_dot_location_two)
+        if (next_dot_location_one < 0):
+            if (next_dot_location_two < 0):
+                return int(version_one[prev_dot_location_one:]) <= int(version_two[prev_dot_location_two:]) # if there are no more dots
+            return int(version_one[prev_dot_location_one:]) <= int(version_two[prev_dot_location_two:next_dot_location_two]) # if there are no more dots from one
+        if (next_dot_location_two < 0):
+            return int(version_one[prev_dot_location_one:next_dot_location_one]) <= int(version_two[prev_dot_location_two:]) # if there are no more dots from two
+        if (int(version_one[prev_dot_location_one:next_dot_location_one]) < int(version_two[prev_dot_location_two:next_dot_location_two])):
+            return True
+        if (int(version_one[prev_dot_location_one:next_dot_location_one]) > int(version_two[prev_dot_location_two:next_dot_location_two])):
+            return False
+        #else they are equal so far check between next dots
+        prev_dot_location_one = next_dot_location_one+1
+        prev_dot_location_two = next_dot_location_two+1
+    return True #they are equal
 # Curse
 
-def curse(addonpage):
+def curseVersionLink(addonpage, wow_min, wow_max):
+    page = requests.get(addonpage + '/files')
+    page.raise_for_status()   # Raise an exception for HTTP errors
+    contentString = str(page.content)
+    indexOfVer = 0
+    endTag = 0
+    downloadId = 0
+    while(indexOfVer >= 0):
+        indexOfVer = contentString.find('file-link', indexOfVer) # step 1 of 2
+        indexOfVer = contentString.find('>', indexOfVer) + 1  # first char of the version string
+        endTag = contentString.find('</a>', indexOfVer)  # ending tag after the version string
+        indexOfGameVer = contentString.find('<td>', endTag) + 4 #step 1 of 6 column 3
+        indexOfGameVer = contentString.find('<td>', indexOfGameVer) + 4 #step 2 of 6 column 4
+        indexOfGameVer = contentString.find('<td>', indexOfGameVer) + 4 #step 3 of 6 column 5
+        indexOfGameVer = contentString.find('<div', indexOfGameVer) + 4 #step 4 of 6 first sub div
+        indexOfGameVer = contentString.find('<div', indexOfGameVer) + 4 #step 5 of 6 second sub div
+        indexOfGameVer = contentString.find('>', indexOfGameVer) + 1 #step 6 of 6 end of sub div
+        endGameTag = contentString.find('</div>', indexOfGameVer) #end of div
+        if (indexOfGameVer < 0 or endGameTag < 0):
+            raise Exception('Unable to find game version')
+        gameVersion = re.sub(r'[\r\n\s]+|\\n|\\r', '', contentString[indexOfGameVer:endGameTag])
+        if (gameVersionLessThanOrEqual(wow_min, gameVersion) and gameVersionLessThanOrEqual(gameVersion, wow_max)):
+            indexOfDownloadId = contentString.find('download/', endGameTag) + 9
+            endDownloadId = contentString.find('"', indexOfDownloadId)
+            if (indexOfDownloadId < 0 or endDownloadId < 0):
+                raise Exception('Unable to find download link')
+            downloadId = contentString[indexOfDownloadId:endDownloadId].strip()
+            break
+    if (indexOfVer < 0 or endTag < 0):
+        raise Exception('Unable to find file matching min and max game version')
+    versionStr = contentString[indexOfVer:endTag].strip()
+    linkStr = addonpage + '/download/' + downloadId + '/file'
+    versionLink = VersionLink(version=versionStr, link=linkStr)
+    return versionLink
+
+
+def curse(addonpage, wow_min, wow_max):
     if '/datastore' in addonpage:
         return curseDatastore(addonpage)
     try:
-        page = requests.get(addonpage + '/download')
-        page.raise_for_status()   # Raise an exception for HTTP errors
-        contentString = str(page.content)
-        searchString = addonpage[26:] + '/download/'
-        indexOfZiploc = contentString.find(searchString)  # Will be the index of the first char of the url
-        endQuote = contentString.find('"', indexOfZiploc)  # Will be the index of the ending quote after the url
-        return 'https://www.curseforge.com' + contentString[indexOfZiploc:endQuote]
-    except Exception:
+        versionLink = curseVersionLink(addonpage, wow_min, wow_max)
+        return versionLink.link
+    except Exception as err:
         print('Failed to find downloadable zip file for addon. Skipping...\n')
+        print("{0}".format(err))
         return ''
 
 def curseDatastore(addonpage):
@@ -135,7 +190,7 @@ def convertOldCurseURL(addonpage):
         print('Failed to find the current page for old URL "' + addonpage + '". Skipping...\n')
         return ''
 
-def getCurseVersion(addonpage):
+def getCurseVersion(addonpage, wow_min, wow_max):
     if '/datastore' in addonpage:
         # For some reason, the dev for the DataStore addons stopped doing releases back around the
         # start of WoD and now just does alpha releases on the project page. So installing the
@@ -143,14 +198,11 @@ def getCurseVersion(addonpage):
         # we'll grab the latest alpha from the project page instead.
         return getCurseDatastoreVersion(addonpage)
     try:
-        page = requests.get(addonpage + '/files')
-        page.raise_for_status()   # Raise an exception for HTTP errors
-        contentString = str(page.content)
-        indexOfVer = contentString.find('text-primary-500 text-lg') + 26 # first char of the version string
-        endTag = contentString.find('</h3>', indexOfVer)  # ending tag after the version string
-        return contentString[indexOfVer:endTag].strip()
-    except Exception:
+        versionLink = curseVersionLink(addonpage, wow_min, wow_max)
+        return versionLink.version
+    except Exception as err:
         print('Failed to find version number for: ' + addonpage)
+        print("{0}".format(err))
         return ''
 
 def getCurseDatastoreVersion(addonpage):

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -27,6 +27,8 @@ class AddonUpdater:
 
         try:
             self.WOW_ADDON_LOCATION = config['WOW ADDON UPDATER']['WoW Addon Location']
+            self.WOW_MIN_VERSION = config['WOW ADDON UPDATER']['WoW Min Version']
+            self.WOW_MAX_VERSION = config['WOW ADDON UPDATER']['WoW Max Version']
             self.ADDON_LIST_FILE = config['WOW ADDON UPDATER']['Addon List File']
             self.INSTALLED_VERS_FILE = config['WOW ADDON UPDATER']['Installed Versions File']
             self.AUTO_CLOSE = config['WOW ADDON UPDATER']['Close Automatically When Completed']
@@ -59,7 +61,7 @@ class AddonUpdater:
                 else:
                     subfolder = ''
                 addonName = SiteHandler.getAddonName(line)
-                currentVersion = SiteHandler.getCurrentVersion(line)
+                currentVersion = SiteHandler.getCurrentVersion(line, self.WOW_MIN_VERSION, self.WOW_MAX_VERSION)
                 if currentVersion is None:
                     currentVersion = 'Not Available'
                 current_node.append(addonName)
@@ -67,7 +69,7 @@ class AddonUpdater:
                 installedVersion = self.getInstalledVersion(line, subfolder)
                 if not currentVersion == installedVersion:
                     print('Installing/updating addon: ' + addonName + ' to version: ' + currentVersion + '\n')
-                    ziploc = SiteHandler.findZiploc(line)
+                    ziploc = SiteHandler.findZiploc(line, self.WOW_MIN_VERSION, self.WOW_MAX_VERSION)
                     install_success = False
                     install_success = self.getAddon(ziploc, subfolder)
                     current_node.append(self.getInstalledVersion(line, subfolder))

--- a/WoWAddonUpdater.py
+++ b/WoWAddonUpdater.py
@@ -93,8 +93,9 @@ class AddonUpdater:
             z = zipfile.ZipFile(BytesIO(r.content))
             self.extract(z, ziploc, subfolder)
             return True
-        except Exception:
+        except Exception as e:
             print('Failed to download or extract zip file for addon. Skipping...\n')
+            print(e + '\n')
             return False
     
     def extract(self, zip, url, subfolder):

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,7 @@
 [WOW ADDON UPDATER]
 WoW Addon Location = c:\Program Files (x86)\World of Warcraft\Interface\AddOns
+WoW Min Version = 2
+WoW Max Version = 999
 Addon List File = in.txt
 Installed Versions File = installed.txt
 Close Automatically When Completed = False


### PR DESCRIPTION
Curseforge updated the layout of their page breaking script.  This update fixes the location of the version and download link.

I also report the exception when downloading as it's useful when running into file permission issues (like can't write to location you specified in the config.ini).